### PR TITLE
Changed TelegramLongPollingBot base code on SpringWebhookBot base code, added keyboard.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,8 +103,8 @@
         <!-- integrations -->
         <dependency>
             <groupId>org.telegram</groupId>
-            <artifactId>telegrambots</artifactId>
-            <version>6.1.0</version>
+            <artifactId>telegrambots-spring-boot-starter</artifactId>
+            <version>6.3.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.api-client</groupId>

--- a/src/main/java/com/ua/javarush/mentor/bot/BotFacade.java
+++ b/src/main/java/com/ua/javarush/mentor/bot/BotFacade.java
@@ -1,0 +1,61 @@
+package com.ua.javarush.mentor.bot;
+
+import com.ua.javarush.mentor.exceptions.GeneralException;
+import com.ua.javarush.mentor.services.TelegramService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+@Component
+@Slf4j
+public class BotFacade {
+
+    private final TelegramService telegramService;
+
+    public BotFacade(TelegramService telegramService) {
+        this.telegramService = telegramService;
+    }
+
+    public SendMessage handleUpdate(Update update) {
+        SendMessage replyMessage = null;
+
+        Message message = update.getMessage();
+        if (message != null && message.hasText()) {
+            log.info("Message '{}' from user with id {}",
+                    update.getMessage().getText(), update.getMessage().getFrom().getId());
+            replyMessage = handleInputMessage(message);
+        }
+
+        return replyMessage;
+    }
+
+    private SendMessage handleInputMessage(Message message) {
+        long chatId = message.getChatId();
+        String textRequest = message.getText().toLowerCase();
+
+        String messageToSend = "Команда не найдена";
+
+        // TODO Нужны состояния бота
+        // TODO Хранение состояний бота
+        // TODO Обработчики состояний
+        // TODO Возможные команды для бота в enum
+        try {
+            if ("/start".equals(textRequest)) {
+                messageToSend = "Привет! Выберите вашу роль...";
+            } else if ("ментор".equals(textRequest)) {
+                messageToSend = "Отправьте email указанный при регистрации";
+            } else if ("администратор".equals(textRequest)) {
+                messageToSend = "Отправьте email указанный при регистрации";
+            }
+
+            return telegramService.sendMessage(chatId, messageToSend);
+
+        } catch (GeneralException e) {
+            //TODO  залоггировать и отправить сообщение о проблеме в чат
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/ua/javarush/mentor/bot/Keyboard.java
+++ b/src/main/java/com/ua/javarush/mentor/bot/Keyboard.java
@@ -1,0 +1,36 @@
+package com.ua.javarush.mentor.bot;
+
+import lombok.Getter;
+import org.springframework.stereotype.Component;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboardMarkup;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.KeyboardButton;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.KeyboardRow;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Component
+public class Keyboard {
+
+    private final String MENTOR_BUTTON_NAME = "Ментор";
+    private final String ADMIN_BUTTON_NAME = "Администратор";
+
+    private final ReplyKeyboardMarkup keyboardMarkup;
+
+    public Keyboard() {
+        this.keyboardMarkup = new ReplyKeyboardMarkup();
+        this.keyboardMarkup.setResizeKeyboard(true);
+        List<KeyboardRow> keyboardRows = new ArrayList<>();
+        KeyboardRow rowMentor = new KeyboardRow();
+        KeyboardRow rowAdmin = new KeyboardRow();
+
+        rowMentor.add(new KeyboardButton(MENTOR_BUTTON_NAME));
+        rowAdmin.add(new KeyboardButton(ADMIN_BUTTON_NAME));
+
+        keyboardRows.add(rowMentor);
+        keyboardRows.add(rowAdmin);
+
+        this.keyboardMarkup.setKeyboard(keyboardRows);
+    }
+}

--- a/src/main/java/com/ua/javarush/mentor/bot/MentorHelperBot.java
+++ b/src/main/java/com/ua/javarush/mentor/bot/MentorHelperBot.java
@@ -1,76 +1,34 @@
 package com.ua.javarush.mentor.bot;
 
-import com.ua.javarush.mentor.enums.AppLocale;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.MessageSource;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.telegram.telegrambots.bots.TelegramLongPollingBot;
-import org.telegram.telegrambots.meta.TelegramBotsApi;
-import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.methods.updates.SetWebhook;
 import org.telegram.telegrambots.meta.api.objects.Update;
-import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
-import org.telegram.telegrambots.updatesreceivers.DefaultBotSession;
+import org.telegram.telegrambots.starter.SpringWebhookBot;
 
 @Slf4j
-@Configuration
-public class MentorHelperBot extends TelegramLongPollingBot {
+@Getter
+public class MentorHelperBot extends SpringWebhookBot {
+    @Setter
     private String botUsername;
+    @Setter
     private String botToken;
-    private final MessageSource messageSource;
+    @Setter
+    private String botPath;
 
-    public MentorHelperBot(MessageSource messageSource) {
-        this.messageSource = messageSource;
-    }
+    private final BotFacade botFacade;
+    private MessageSource messageSource;
 
-    @Bean
-    public MentorHelperBot uploadBot(@Value("${telegramBot.username}") String botUsername,
-                                     @Value("${telegramBot.token}") String botToken) {
-        this.botUsername = botUsername;
-        this.botToken = botToken;
-        try {
-            TelegramBotsApi telegramBotsApi = new TelegramBotsApi(DefaultBotSession.class);
-            telegramBotsApi.registerBot(this);
-            log.info("Bot {} was registered", botUsername);
-        } catch (TelegramApiException e) {
-            log.error("Error while registering bot", e);
-        }
-        return this;
+    public MentorHelperBot(SetWebhook setWebhook, BotFacade botFacade) {
+        super(setWebhook);
+        this.botFacade = botFacade;
     }
 
     @Override
-    public void onUpdateReceived(Update update) {
-        if (update.hasMessage() && update.getMessage().hasText()) {
-            log.info("Message '{}' from user with id {}", update.getMessage().getText(), update.getMessage().getFrom().getId());
-            SendMessage message = new SendMessage();
-            message.setChatId(update.getMessage().getChatId());
-
-            String messageText = update.getMessage().getText() != null ? update.getMessage().getText() : "";
-            switch (messageText) {
-                case "/start":
-                    String greetings = messageSource.getMessage("telegram.greeting", null, AppLocale.UA.getLocaleObject());
-                    message.setText(greetings);
-                    break;
-                default:
-                    String unknownCommand = messageSource.getMessage("telegram.unknownCommand", null,  AppLocale.UA.getLocaleObject());
-                    message.setText(unknownCommand);
-            }
-            try {
-                execute(message);
-            } catch (TelegramApiException e) {
-                throw new IllegalStateException(e);
-            }
-        }
-    }
-
-    @Override
-    public String getBotToken() {
-        return botToken;
-    }
-
-    @Override
-    public String getBotUsername() {
-        return botUsername;
+    public BotApiMethod<?> onWebhookUpdateReceived(Update update) {
+        return botFacade.handleUpdate(update);
     }
 }

--- a/src/main/java/com/ua/javarush/mentor/config/BotConfig.java
+++ b/src/main/java/com/ua/javarush/mentor/config/BotConfig.java
@@ -1,0 +1,38 @@
+package com.ua.javarush.mentor.config;
+
+import com.ua.javarush.mentor.bot.MentorHelperBot;
+import com.ua.javarush.mentor.bot.BotFacade;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.telegram.telegrambots.meta.api.methods.updates.SetWebhook;
+
+@Getter
+@Configuration
+public class BotConfig {
+
+    @Value("${telegramBot.username}")
+    private String botToken;
+
+    @Value("${telegramBot.token}")
+    private String botUsername;
+
+    @Value("${telegramBot.path}")
+    private String botPath;
+
+    @Bean
+    public SetWebhook setWebhookInstance() {
+        return SetWebhook.builder().url(getBotPath()).build();
+    }
+
+    @Bean
+    public MentorHelperBot mentorHelperBot(SetWebhook setWebhookInstance, BotFacade botFacade) {
+        MentorHelperBot mentorHelperBot = new MentorHelperBot(setWebhookInstance, botFacade);
+        mentorHelperBot.setBotToken(getBotToken());
+        mentorHelperBot.setBotUsername(getBotUsername());
+        mentorHelperBot.setBotPath(getBotPath());
+
+        return mentorHelperBot;
+    }
+}

--- a/src/main/java/com/ua/javarush/mentor/controller/rest/WebhookController.java
+++ b/src/main/java/com/ua/javarush/mentor/controller/rest/WebhookController.java
@@ -1,0 +1,24 @@
+package com.ua.javarush.mentor.controller.rest;
+
+import com.ua.javarush.mentor.bot.MentorHelperBot;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+@RestController
+public class WebhookController {
+
+    private final MentorHelperBot mentorHelperBot;
+
+    public WebhookController(MentorHelperBot mentorHelperBot) {
+        this.mentorHelperBot = mentorHelperBot;
+    }
+
+    @PostMapping("/")
+    public BotApiMethod<?> onUpdateReceived(@RequestBody Update update) {
+        return mentorHelperBot.onWebhookUpdateReceived(update);
+    }
+
+}

--- a/src/main/java/com/ua/javarush/mentor/security/SecurityConfig.java
+++ b/src/main/java/com/ua/javarush/mentor/security/SecurityConfig.java
@@ -16,6 +16,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
@@ -67,6 +68,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                .csrf().disable()
                 .formLogin()
                     .loginPage(WEB_LOGIN)
                     .failureUrl(WEB_LOGIN + ERROR_TRUE)

--- a/src/main/java/com/ua/javarush/mentor/services/TelegramService.java
+++ b/src/main/java/com/ua/javarush/mentor/services/TelegramService.java
@@ -1,7 +1,8 @@
 package com.ua.javarush.mentor.services;
 
 import com.ua.javarush.mentor.exceptions.GeneralException;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 
 public interface TelegramService {
-    void sendMessage(Long userId, String message) throws GeneralException;
+    SendMessage sendMessage(Long userId, String message) throws GeneralException;
 }

--- a/src/main/java/com/ua/javarush/mentor/services/impl/TelegramServiceImpl.java
+++ b/src/main/java/com/ua/javarush/mentor/services/impl/TelegramServiceImpl.java
@@ -1,6 +1,6 @@
 package com.ua.javarush.mentor.services.impl;
 
-import com.ua.javarush.mentor.bot.MentorHelperBot;
+import com.ua.javarush.mentor.bot.Keyboard;
 import com.ua.javarush.mentor.exceptions.UiError;
 import com.ua.javarush.mentor.exceptions.GeneralException;
 import com.ua.javarush.mentor.services.TelegramService;
@@ -15,16 +15,16 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 @Service
 public class TelegramServiceImpl implements TelegramService {
 
-    private final MentorHelperBot mentorHelperBot;
+    private final Keyboard keyboard;
 
-    public TelegramServiceImpl(MentorHelperBot mentorHelperBot) {
-        this.mentorHelperBot = mentorHelperBot;
+    public TelegramServiceImpl(Keyboard keyboard) {
+        this.keyboard = keyboard;
     }
 
     @Override
-    public void sendMessage(Long userId, String message) throws GeneralException {
+    public SendMessage sendMessage(Long userId, String message) throws GeneralException {
         try {
-            mentorHelperBot.execute(buildMessage(userId, message));
+            return buildMessage(userId, message);
         } catch (Exception e) {
             log.error("Error while sending message to user with id {}", userId, e);
             throw createGeneralException("Cannot send message to user with id " + userId, BAD_REQUEST, UiError.TELEGRAM_SEND_MESSAGE_ERROR, e);
@@ -36,6 +36,9 @@ public class TelegramServiceImpl implements TelegramService {
         SendMessage sendMessage = new SendMessage();
         sendMessage.setChatId(userId);
         sendMessage.setText(message);
+
+        sendMessage.setReplyMarkup(keyboard.getKeyboardMarkup());
+        sendMessage.enableHtml(true);
         return sendMessage;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,8 @@
 #Bot settings
+server.port=${MENTOR_BOT_SERVER_PORT}
 telegramBot.username=${MENTOR_BOT_USERNAME}
 telegramBot.token=${MENTOR_BOT_TOKEN}
+telegramBot.path=${MENTOR_BOT_PATH}
 
 #Database settings
 spring.datasource.url=jdbc:postgresql://localhost:5432/mentorhelperdb


### PR DESCRIPTION
# PR details

- changed TelegramLongPollingBot base code on SpringWebhookBot base code
- added keyboard
- disabled csrf-token
- added in application.properties server port and webhook path

**A webhook with an HTTPS protocol is required to run the bot.**  

Set webhook path in the `application.properties` file. 
For registration enter in browser:
`https://api.telegram.org/bot{BOT_TOKEN}/setWebhook?url={WEBHOOK_URL}`  

You will receive a response that the webhook has been set:
`{"ok":true,"result":true,"description":"Webhook was set"}`  

To view information enter in browser:
`https://api.telegram.org/bot{BOT_TOKEN}/getWebhookInfo`

You can use the ngrok service to generate a temporary webhook.  
The URL will be valid for 2 hours, after which you can generate a new one if needed.

- Download and install `ngrok` from the [link](https://ngrok.com/download)  
- Start the service in the console with the command `ngrok http 5000` (the port can be different).